### PR TITLE
Some additions to the code

### DIFF
--- a/libcam86.h
+++ b/libcam86.h
@@ -26,8 +26,8 @@
 
 #define BRA 20
 #define BRB 5
-#define CAM86_LATENCYA  1
-#define CAM86_LATENCYB  1
+#define CAM86_LATENCYA  2
+#define CAM86_LATENCYB  2
 #define CAM86_TIMERA    30
 #define CAM86_TIMERB    10
 


### PR DESCRIPTION
Improved ftdi_read_data function that uses timeouts instead of fixed number of loops.
Use default constants instead of hardcoded latencies/timeouts.
Set default latency to 2 as I read comments that latency of 1 can lead to data loss.